### PR TITLE
Revert "Add a timestamp to slackin badge" fixing badge not refreshing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 iojs-cn
 ----------
 
-参加 Slack 上的实时讨论：[![Join the chat at https://iojs-cn.slack.com](https://iojs-cn.herokuapp.com/badge.svg/?t=2015)](https://iojs-cn.herokuapp.com)
+参加 Slack 上的实时讨论：[![Join the chat at https://iojs-cn.slack.com](https://iojs-cn.herokuapp.com/badge.svg)](https://iojs-cn.herokuapp.com)
 
 > iojs-cn 组织成立的目的是为了推进 [io.js](https://iojs.org/) 在中国的普及，并及时同步英文社区的最新资讯。
 


### PR DESCRIPTION
Reverts iojs/iojs-cn#42. The timestamp was never necessary, because GitHub cache images anyway, unless the original response headers explicitly say `no-cache`. This is fixed on the side of slackin app.
